### PR TITLE
Fixed CurvePropertyType xlink:href

### DIFF
--- a/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ext/CurvePropertyTypeBinding.java
+++ b/modules/extension/xsd/xsd-gml3/src/main/java/org/geotools/gml3/bindings/ext/CurvePropertyTypeBinding.java
@@ -88,16 +88,6 @@ public class CurvePropertyTypeBinding extends org.geotools.gml3.bindings.CurvePr
         return node.getChildValue(LineString.class);
     }
 
-    @Override
-    public Object getProperty(Object object, QName name)
-        throws Exception {
-        if ("_Curve".equals(name.getLocalPart()) || "AbstractCurve".equals(name.getLocalPart())) {
-            return object;
-        }
-        
-        return super.getProperty(object, name);
-    }
-
     public int compareTo(Object o) {
         if (o instanceof CurveTypeBinding) {
             return 1;


### PR DESCRIPTION
Fixes reported build failure in GeoServer gs-app-schema-test XlinkGeometryTest when encoding CurvePropertyType with xlink:href:
http://osgeo-org.1560.x6.nabble.com/App-schema-xlinks-and-curves-td5150642.html

The fix is to remove an old getProperty override as the base class has become smart enough to handle this situation.
